### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -18,14 +18,14 @@ jobs:
         if: ${{ steps.docker-image.outputs.exists == 'false' }}
         run: |
           echo response=$(curl -s --head -w %{http_code} https://runtime.fivem.net/artifacts/fivem/build_proot_linux/master/$(curl -sH "Accept: application/vnd.github.v3+json" --url "https://api.github.com/repos/citizenfx/fivem/tags?per_page=100" | jq -r 'first(.[] | {name: .name | match("v1.0.0.(${{ steps.latest-fivem-tag.outputs.tag }})").captures | .[].string, hash: .commit.sha} | join("-"))')/fx.tar.xz -o /dev/null) >> $GITHUB_OUTPUT
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: ${{ steps.fxserver-artifact.outputs.response == '200' }}
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         if: ${{ steps.fxserver-artifact.outputs.response == '200' }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: docker/build-push-action@v3
+      - uses: docker/build-push-action@v6
         if: ${{ steps.fxserver-artifact.outputs.response == '200' }}
         with:
           push: true


### PR DESCRIPTION
to fix deprecation warnings, for instance on https://github.com/TrAsKiN/fxserver/actions/runs/9795190271

no breaking changes as far as i could tell.

see:

- https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
- example run https://github.com/madmini/traskin-fxserver/actions/runs/9810454681
- dockerhub release https://hub.docker.com/r/dermini/fxserver2/tags