### PR TITLE
Add run.sh script to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apk -U upgrade --no-cache && apk -U add --no-cache curl jq && \
 
 FROM scratch
 COPY --from=base /tmp/alpine/ /
+COPY --from=base /tmp/run.sh /run.sh
 EXPOSE 30120/tcp 30120/udp 40120
 WORKDIR /opt/cfx-server/
 ENTRYPOINT ["/opt/cfx-server/run.sh"]


### PR DESCRIPTION
Recently FiveM changes the way the yarn and webpack work, due to the sandboxing changes, this completely breaks webpack and yarn on docker as the resources are no longer overwritable, which was my fix before the make yarn and webpack work.

When using the normal run.sh from the alpine zip it does work however, so that's my fix for now by overriding the file on startup, but to make it easier to use it would be nice if the file is included into the docker image.

I didn't edit the entrypoint on purpose as to leave this as a choice and not a forced change.